### PR TITLE
Detect yarn.lock file during init

### DIFF
--- a/lib/mix/tasks/init.ex
+++ b/lib/mix/tasks/init.ex
@@ -1,8 +1,14 @@
 defmodule Mix.Tasks.Smoothie.Init do
   use Mix.Task
   @shortdoc "Initializes smoothie"
+  @package_version "elixir-smoothie@2.X"
 
   def run(_) do
-    System.cmd "npm", ["i", "elixir-smoothie@2.X", "--save-dev"], into: IO.stream(:stdio, :line)
+    case File.read("yarn.lock") do
+      {:ok, _} ->
+        System.cmd "yarn", ["add", @package_version, "--dev"], into: IO.stream(:stdio, :line)
+      {:error, _} ->
+        System.cmd "npm", ["i", @package_version, "--save-dev"], into: IO.stream(:stdio, :line)
+    end
   end
 end


### PR DESCRIPTION
If yarn.lock file exists, use `yarn add [package]`. If the file doesn't
exist, fallback to `npm install`.