### PR TITLE
Some changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: true
 language: elixir
 
 before_install:
-  - git clone https://github.com/stephenmoloney/elixir-smoothie.git ../elixir-smoothie
+  - git clone https://github.com/jfrolich/elixir-smoothie.git ../elixir-smoothie
   - curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh -o install_nvm.sh && bash install_nvm.sh && source ~/.profile
   - nvm install 7.8.0 && nvm use 7.8.0
   - nvm alias default 7.8.0 && nvm use default

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: true
+
+language: elixir
+
+before_install:
+  - curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh -o install_nvm.sh && bash install_nvm.sh && source ~/.profile
+  - nvm install 7.8.0 && nvm use 7.8.0
+  - nvm alias default 7.8.0 && nvm use default
+  - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+  - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update && sudo apt-get install yarn
+
+otp_release:
+  - 19.2
+
+elixir:
+  - 1.4.2
+
+script:
+  - yarn install
+  - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_install:
   - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
   - echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
   - sudo apt-get update && sudo apt-get install yarn
+  - yarn install
 
 otp_release:
   - 19.2
@@ -17,5 +18,4 @@ elixir:
   - 1.4.2
 
 script:
-  - yarn install
   - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: true
 language: elixir
 
 before_install:
+  - git clone https://github.com/stephenmoloney/elixir-smoothie.git ../elixir-smoothie
   - curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.1/install.sh -o install_nvm.sh && bash install_nvm.sh && source ~/.profile
   - nvm install 7.8.0 && nvm use 7.8.0
   - nvm alias default 7.8.0 && nvm use default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@
 - Update dependencies for documentation generation
 - Slight change to the way the path is generated, same outcome but allows for where
 the user enters `../../path` - before this would not expand to the correct path. With
-changes, it should do so.
+changes, it should do so. Might be needed for umbrella apps and if putting templates
+`../assets` directory.
 - Added test for expected empty mock function on compilation failure
 - Added test for where the `:template_build_dir` is being used.
 - Minor changes to syntax and readme.
 - Requires upgrading to new companion of elixir-smoothie, `> 2.0.5`.
+
+
+## v3.0.0
+
+- This release is a breaking change.
+
+[breaking changes]
+When you pass attributes to the template function (such as welcome_html(user: user)),
+previously you needed <%= user %> in your template to reference the user attribute.
+This worked by using a naive implementation,
+and this is why in the previous version it was impossible to do other things in
+elixir syntax than just including that variable
+(for instance <%= String.upcase(user) %> would not work).
+This is changed in 3.0.0 however we need to change our templates to invoke
+attributes using module attributes: <%= @user %>.
+This is more in line of how the templating works in the rest of elixir,
+and allows us to build more flexible templates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## v3.1.0
+
+- Option to set the `:template_build_dir` in `config smoothie: ...`
+- Anticipate new directory structure for pre phoenix 1.3 and post phoenix 1.3
+- Update dependencies for documentation generation
+- Slight change to the way the path is generated, same outcome but allows for where
+the user enters `../../path` - before this would not expand to the correct path. With
+changes, it should do so.
+- Added test for expected empty mock function on compilation failure
+- Added test for where the `:template_build_dir` is being used.
+- Minor changes to syntax and readme.
+- Requires upgrading to new companion of elixir-smoothie, `> 2.0.5`.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,22 @@
+# MIT License
+
+Copyright (c) 2016 -2017 Jaap Frolick, Stephen Moloney
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 # MIT License
 
-Copyright (c) 2016 -2017 Jaap Frolick, Stephen Moloney
+Copyright (c) 2016 -2017 Jaap Frolich, Stephen Moloney
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Smoothie can be installed as:
 
     ```elixir
     def deps do
-      [{:smoothie, "~> 2.0.0"}]
+      [{:smoothie, "~> 3.0"}]
     end
     ```
 
@@ -319,5 +319,9 @@ Smoothie needs to install a npm library to do the css inlining, so make sure you
 ## Tests
 
 ```
-npm install -d && mix test
+yarn install && mix test
 ```
+
+## TODO
+
+- [ ] Create example usage repository (and link to README)

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,3 +1,3 @@
 use Mix.Config
 
-config :smoothie, modules: [Css.Mailer, Scss.Mailer, Foundation.Mailer]
+config :smoothie, modules: [Build.Mailer, Css.Mailer, Scss.Mailer, Foundation.Mailer]

--- a/lib/mix/tasks/compile.ex
+++ b/lib/mix/tasks/compile.ex
@@ -6,26 +6,29 @@ defmodule Mix.Tasks.Smoothie.Compile do
   def run(_) do
     Mix.Tasks.Loadpaths.run([])
 
-    modules = Application.get_env(:smoothie, :modules)
-    if modules == nil, do: raise("Smoothie: No smoothie modules options found to compile. Set config :smoothie, modules: [MyApp.MyModule].")
+    modules = Application.get_env(:smoothie, :modules, :nil) ||
+    raise("Smoothie: No smoothie modules options found to compile. Set config :smoothie, modules: [MyApp.MyModule].")
+
+    path = Path.join([File.cwd!(), "node_modules/.bin/elixir-smoothie"])
+    path = File.exists?(path) && path || Path.join([File.cwd!(), "assets/node_modules/.bin/elixir-smoothie"])
 
     for module <- modules do
-      path = Path.join([File.cwd!, "node_modules/.bin/elixir-smoothie"])
       # try to ensure the project is compiled and that __smoothie__ functions are available first
       try do
-        module.__smoothie_template_path__
+        module.__smoothie_template_path__()
       rescue
         _e in UndefinedFunctionError ->
-          Mix.Shell.IO.info("module.__smoothie_template_path__ function has not been defined")
+          Mix.Shell.IO.info("module.__smoothie_template_path__() function has not been defined")
           Mix.Shell.IO.info("Perhaps  #{Mix.Project.config()[:app]} has not been compiled yet.")
           Mix.Shell.IO.yes?("Do you wish to compile #{Mix.Project.config()[:app]} ?") && Mix.Tasks.Compile.run([])
       end
       env = [
-        {"SMOOTHIE_TEMPLATE_DIR", module.__smoothie_template_path__},
-        {"SMOOTHIE_LAYOUT_FILE", module.__smoothie_layout_path__},
-        {"SMOOTHIE_USE_FOUNDATION", if(module.__smoothie_use_foundation__, do: "true", else: "false")},
-        {"SMOOTHIE_SCSS_FILE", module.__smoothie_scss_path__},
-        {"SMOOTHIE_CSS_FILE", module.__smoothie_css_path__},
+        {"SMOOTHIE_TEMPLATE_DIR", module.__smoothie_template_path__()},
+        {"SMOOTHIE_BUILD_TEMPLATE_DIR", module.__smoothie_template_build_path__()},
+        {"SMOOTHIE_LAYOUT_FILE", module.__smoothie_layout_path__()},
+        {"SMOOTHIE_USE_FOUNDATION", if(module.__smoothie_use_foundation__(), do: "true", else: "false")},
+        {"SMOOTHIE_SCSS_FILE", module.__smoothie_scss_path__()},
+        {"SMOOTHIE_CSS_FILE", module.__smoothie_css_path__()},
       ]
       System.cmd(path, [], env: env, into: IO.stream(:stdio, :line))
     end

--- a/lib/mix/tasks/init.ex
+++ b/lib/mix/tasks/init.ex
@@ -2,13 +2,29 @@ defmodule Mix.Tasks.Smoothie.Init do
   use Mix.Task
   @shortdoc "Initializes smoothie"
   @package_version "elixir-smoothie@2.X"
+  @root "./"
+  @assets "./assets"
+  @standard_opts [into: IO.stream(:stdio, :line), cd: @root]
+  @new_opts [into: IO.stream(:stdio, :line), cd: @assets]
 
   def run(_) do
-    case File.read("yarn.lock") do
-      {:ok, _} ->
-        System.cmd "yarn", ["add", @package_version, "--dev"], into: IO.stream(:stdio, :line)
-      {:error, _} ->
-        System.cmd "npm", ["i", @package_version, "--save-dev"], into: IO.stream(:stdio, :line)
+    try do
+      do_init()
+    rescue
+      _error ->
+        System.cmd "npm", ["i", @package_version, "--save-dev", @new_opts]
     end
   end
+
+  defp do_init() do
+    case File.read("yarn.lock") do
+      {:ok, _} ->
+        System.cmd("yarn", ["add", @package_version, "--dev"], @standard_opts)
+      {:error, :enoent} ->
+        System.cmd("yarn", ["add", @package_version, "--dev"], @new_opts)
+      {:error, _} ->
+        System.cmd "npm", ["i", @package_version, "--save-dev", @standard_opts]
+    end
+  end
+
 end

--- a/lib/smoothie.ex
+++ b/lib/smoothie.ex
@@ -1,6 +1,11 @@
 defmodule Smoothie do
   require EEx
 
+
+  @doc :false
+  def expand(:nil), do: :nil
+  def expand(path), do: Path.expand(path)
+
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
       require Logger
@@ -9,25 +14,32 @@ defmodule Smoothie do
       @smoothie_path Path.expand(__ENV__.file) |> Path.dirname()
       @use_foundation Keyword.get(opts, :use_foundation, :false)
       @template_dir Keyword.get(opts, :template_dir, :nil)
-      @template_build_path Keyword.get(opts, :template_build_dir, Path.join(@template_dir, "build"))
+      @template_path Path.join(@smoothie_path, @template_dir) |> Smoothie.expand()
+      @template_build_dir Keyword.get(opts, :template_build_dir, Path.join(@template_dir, "build"))
+      @template_build_path Path.join(@smoothie_path, @template_build_dir) |> Smoothie.expand()
       @layout_file Keyword.get(opts, :layout_file, :nil)
+      @layout_path @layout_file && (Path.join(@smoothie_path, @layout_file) |> Smoothie.expand())
       @scss_file Keyword.get(opts, :scss_file, :nil)
+      @scss_path @scss_file && Path.join(@smoothie_path, @scss_file) |> Smoothie.expand()
       @css_file Keyword.get(opts, :css_file, :nil)
+      @css_path @css_file && Path.join(@smoothie_path, @css_file) |> Smoothie.expand()
 
-      File.exists?(@template_dir) || raise("Smoothie: Template path not found: '#{@template_dir}'")
+      File.exists?(@template_path) || raise("Smoothie: Template path not found: '#{@template_path}'")
       File.exists?(@template_build_path) || File.mkdir!(@template_build_path)
-      File.exists?(@layout_file) || raise("Smoothie: Layout file not found: '#{@layout_file}'")
-      @layout_file|| raise("Smoothie: Layout file not found: '#{@layout_file}'")
+      File.exists?(@layout_path) || raise("Smoothie: Layout file not found: '#{@layout_path}'")
+      @layout_path|| raise("Smoothie: Layout file not found: '#{@layout_path}'")
       @template_files File.ls!(@template_build_path)
+
 
       def __smoothie_path__(), do: @smoothie_path
       def __smoothie_use_foundation__(), do: @use_foundation
-      def __smoothie_template_path__(), do: @template_dir
+      def __smoothie_template_path__(), do: @template_path
       def __smoothie_template_build_path__(), do: @template_build_path
-      def __smoothie_layout_path__, do: @layout_file
-      def __smoothie_scss_path__(), do: @scss_file
-      def __smoothie_css_path__(), do: @css_file
-      def __smoothie__, do: true
+      def __smoothie_layout_path__, do: @layout_path
+      def __smoothie_scss_path__(), do: @scss_path
+      def __smoothie_css_path__(), do: @css_path
+      def __smoothie__(), do: :true
+
 
       # Ensure the macro is recompiled when the templates are changed
       Enum.each(@template_files, fn(file) ->
@@ -49,7 +61,7 @@ defmodule Smoothie do
 
       # create mock functions to avoid compilation deadlock on first `clean` compilation
       if @template_files == [] do
-        Enum.filter(File.ls!(@template_dir), &(String.contains?(&1, ".html.eex")))
+        Enum.filter(File.ls!(@template_path), &(String.contains?(&1, ".html.eex")))
         |> Enum.each(fn(file) ->
           funcs = [
           file

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,11 @@
 defmodule Smoothie.Mixfile do
   use Mix.Project
+    @version "3.1.0"
 
   def project do
     [
       app: :smoothie,
-      version: "3.0.0",
+      version: @version,
       elixir: "~> 1.2",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -55,6 +55,15 @@ defmodule Smoothie.Mixfile do
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib", "test/data/css", "test/data/scss", "test/data/foundation"]
+  defp elixirc_paths(:test) do
+    [
+      "lib",
+      "test/data/build",
+      "test/data/css",
+      "test/data/scss",
+      "test/data/foundation",
+      "test/data/no_compile"
+    ]
+  end
   defp elixirc_paths(_), do: ["lib"]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,2 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+%{"earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}

--- a/test/data/build/mailer.ex
+++ b/test/data/build/mailer.ex
@@ -1,6 +1,7 @@
-defmodule Scss.Mailer do
+defmodule Build.Mailer do
   use Smoothie,
     template_dir: Path.join(["templates"]),
+    template_build_dir: Path.join(["templates", "build"]),
     layout_file: Path.join(["templates", "layout", "layout.html.eex"]),
     scss_file: Path.join(["templates", "layout", "style.scss"])
   @user "Elixir Developer"

--- a/test/data/build/templates/build/welcome.html.eex
+++ b/test/data/build/templates/build/welcome.html.eex
@@ -1,0 +1,4 @@
+<h1 style="text-decoration: line-through;">Test</h1>
+<h2>Welcome!</h2>
+Hi <%= @user %>
+

--- a/test/data/build/templates/build/welcome.txt.eex
+++ b/test/data/build/templates/build/welcome.txt.eex
@@ -1,0 +1,3 @@
+Test
+Welcome!
+Hi <%= @user %>

--- a/test/data/build/templates/layout/layout.html.eex
+++ b/test/data/build/templates/layout/layout.html.eex
@@ -1,0 +1,2 @@
+<h1>Test</h1>
+{content}

--- a/test/data/build/templates/layout/style.scss
+++ b/test/data/build/templates/layout/style.scss
@@ -1,0 +1,3 @@
+h1 {
+  text-decoration: line-through;
+}

--- a/test/data/build/templates/snapshots/assigned/welcome.html
+++ b/test/data/build/templates/snapshots/assigned/welcome.html
@@ -1,0 +1,4 @@
+<h1 style="text-decoration: line-through;">Test</h1>
+<h2>Welcome!</h2>
+Hi Elixir Developer
+

--- a/test/data/build/templates/snapshots/assigned/welcome.txt
+++ b/test/data/build/templates/snapshots/assigned/welcome.txt
@@ -1,0 +1,3 @@
+Test
+Welcome!
+Hi Elixir Developer

--- a/test/data/build/templates/snapshots/unassigned/welcome.html.eex
+++ b/test/data/build/templates/snapshots/unassigned/welcome.html.eex
@@ -1,0 +1,3 @@
+<h1 style="text-decoration: line-through;">Test</h1>
+<h2>Welcome!</h2>
+Hi <%= @user %>

--- a/test/data/build/templates/snapshots/unassigned/welcome.txt.eex
+++ b/test/data/build/templates/snapshots/unassigned/welcome.txt.eex
@@ -1,0 +1,3 @@
+Test
+Welcome!
+Hi <%= @user %>

--- a/test/data/build/templates/welcome.html.eex
+++ b/test/data/build/templates/welcome.html.eex
@@ -1,0 +1,2 @@
+<h2>Welcome!</h2>
+Hi <%= @user %>

--- a/test/data/no_compile/mailer.ex
+++ b/test/data/no_compile/mailer.ex
@@ -1,4 +1,4 @@
-defmodule Scss.Mailer do
+defmodule NoCompile.Mailer do
   use Smoothie,
     template_dir: Path.join(["templates"]),
     layout_file: Path.join(["templates", "layout", "layout.html.eex"]),

--- a/test/data/no_compile/templates/layout/layout.html.eex
+++ b/test/data/no_compile/templates/layout/layout.html.eex
@@ -1,0 +1,2 @@
+<h1>Test</h1>
+{content}

--- a/test/data/no_compile/templates/layout/style.scss
+++ b/test/data/no_compile/templates/layout/style.scss
@@ -1,0 +1,3 @@
+h1 {
+  text-decoration: line-through;
+}

--- a/test/data/no_compile/templates/snapshots/assigned/welcome.html
+++ b/test/data/no_compile/templates/snapshots/assigned/welcome.html
@@ -1,0 +1,4 @@
+<h1 style="text-decoration: line-through;">Test</h1>
+<h2>Welcome!</h2>
+Hi Elixir Developer
+

--- a/test/data/no_compile/templates/snapshots/assigned/welcome.txt
+++ b/test/data/no_compile/templates/snapshots/assigned/welcome.txt
@@ -1,0 +1,3 @@
+Test
+Welcome!
+Hi Elixir Developer

--- a/test/data/no_compile/templates/snapshots/unassigned/welcome.html.eex
+++ b/test/data/no_compile/templates/snapshots/unassigned/welcome.html.eex
@@ -1,0 +1,3 @@
+<h1 style="text-decoration: line-through;">Test</h1>
+<h2>Welcome!</h2>
+Hi <%= @user %>

--- a/test/data/no_compile/templates/snapshots/unassigned/welcome.txt.eex
+++ b/test/data/no_compile/templates/snapshots/unassigned/welcome.txt.eex
@@ -1,0 +1,3 @@
+Test
+Welcome!
+Hi <%= @user %>

--- a/test/data/no_compile/templates/welcome.html.eex
+++ b/test/data/no_compile/templates/welcome.html.eex
@@ -1,0 +1,2 @@
+<h2>Welcome!</h2>
+Hi <%= @user %>

--- a/test/data/scss/mailer.ex
+++ b/test/data/scss/mailer.ex
@@ -1,6 +1,7 @@
 defmodule Scss.Mailer do
   use Smoothie,
     template_dir: Path.join(["templates"]),
+    template_build_dir: Path.join(["templates", "build"]),
     layout_file: Path.join(["templates", "layout", "layout.html.eex"]),
     scss_file: Path.join(["templates", "layout", "style.scss"])
   @user "Elixir Developer"

--- a/test/no_compile_test.exs
+++ b/test/no_compile_test.exs
@@ -1,0 +1,25 @@
+defmodule NoCompileTest do
+  use ExUnit.Case
+
+  def clean_build_dir() do
+    no_compile = Path.expand("test/data/no_compile/templates/build")
+    File.exists?(no_compile) && File.rm_rf!(no_compile)
+  end
+
+  setup_all do
+    clean_build_dir()
+    :ok
+  end
+  test "raises an error when the mix smoothie.compile task has not yet been run for NoCompile.Mailer" do
+    assert_raise(RuntimeError, fn() ->
+      try do
+        NoCompile.Mailer.html()
+      rescue
+        e in RuntimeError ->
+          assert e.message == "welcome.html.eex has not yet been compiled by smoothie, run `mix smoothie.compile`."
+          raise(RuntimeError, message: e.message)
+      end
+    end)
+  end
+
+end

--- a/test/smoothie_test.exs
+++ b/test/smoothie_test.exs
@@ -1,5 +1,5 @@
 defmodule SmoothieTest do
-  use ExUnit.Case, async: :false
+  use ExUnit.Case
   doctest Smoothie
 
   @modules [

--- a/test/smoothie_test.exs
+++ b/test/smoothie_test.exs
@@ -1,8 +1,9 @@
 defmodule SmoothieTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: :false
   doctest Smoothie
 
   @modules [
+    Build.Mailer,
     Scss.Mailer,
     Css.Mailer,
     Foundation.Mailer
@@ -49,4 +50,5 @@ defmodule SmoothieTest do
       assert(trim(actual_text) == trim(expected_text))
     end
   end
+
 end


### PR DESCRIPTION
- Option to set the :template_build_dir in config smoothie.
- Anticipate new directory structure for pre phoenix 1.3 and post phoenix 1.3
- Update dependencies for documentation generation
- Slight change to the way the path is generated, same outcome but allows for where the user enters ../../path - before this would not expand to the correct path. With changes, it should do so. Might be needed for umbrella apps and if putting templates ../assets directory.
- Added test for expected empty mock function on compilation failure
- Added test for where the :template_build_dir is being used.
- Minor changes to syntax and readme.
- For this to work, ***requires upgrading to new companion of elixir-smoothie, > 2.0.5.***, see 
pull request to `elixir-smoothie` for that