### PR TITLE
Add HTML only option to skip generating text templates (#9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,36 +283,55 @@ Done 🙏
 
 Done! Now we are able to send very beautifully styled templates with styles inlined so it works in every email client, and for we also have a nice plain text version of the email!
 
+## Text templates
+
+Smoothie automatically generates `txt.eex` templates from your `html.eex` files. If you don't like them, you can provide your own `txt.eex` templates by saving them to the same directory as your `html.eex` files.
+
+```
+/build
+/layout
+welcome.html.eex
+welcome.txt.eex
+```
+
+To skip generating text templates altogether, set `:html_only` in your config,
+
+```elixir
+config :smoothie, html_only: true
+```
+
+or run `mix smoothie.compile --html-only`.
+
 ## Installation
 
 Smoothie can be installed as:
 
   1. Add `smoothie` to your list of dependencies in `mix.exs`:
 
-    ```elixir
-    def deps do
-      [{:smoothie, "~> 3.0"}]
-    end
-    ```
+  ```elixir
+  def deps do
+    [{:smoothie, "~> 3.0"}]
+  end
+  ```
 
   2. Ensure `smoothie` is started before your application:
 
-    ```elixir
-    def application do
-      [applications: [:smoothie]]
-    end
-    ```
+  ```elixir
+  def application do
+    [applications: [:smoothie]]
+  end
+  ```
 
   3. The only thing left is install the npm package that smoothie relies on in your project, we can do this with the following command:
 
-    ```
-      > mix smoothie.init
-    ```
+  ```
+    > mix smoothie.init
+  ```
 
-    Compile with layout
-    ```
-      > mix smoothie.compile
-    ```
+  Compile with layout
+  ```
+    > mix smoothie.compile
+  ```
 
 Smoothie needs to install a npm library to do the css inlining, so make sure you have npm initialized in your project (a `package.json` file in your project's root)
 

--- a/lib/mix/tasks/compile.ex
+++ b/lib/mix/tasks/compile.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Smoothie.Compile do
   require Logger
   @shortdoc "Compiles smoothie templates"
 
-  def run(_) do
+  def run(argv) do
     Mix.Tasks.Loadpaths.run([])
 
     modules = Application.get_env(:smoothie, :modules, :nil) ||
@@ -11,6 +11,8 @@ defmodule Mix.Tasks.Smoothie.Compile do
 
     path = Path.join([File.cwd!(), "node_modules/.bin/elixir-smoothie"])
     path = File.exists?(path) && path || Path.join([File.cwd!(), "assets/node_modules/.bin/elixir-smoothie"])
+
+    html_only = html_only?(argv) |> Atom.to_string()
 
     for module <- modules do
       # try to ensure the project is compiled and that __smoothie__ functions are available first
@@ -29,10 +31,20 @@ defmodule Mix.Tasks.Smoothie.Compile do
         {"SMOOTHIE_USE_FOUNDATION", if(module.__smoothie_use_foundation__(), do: "true", else: "false")},
         {"SMOOTHIE_SCSS_FILE", module.__smoothie_scss_path__()},
         {"SMOOTHIE_CSS_FILE", module.__smoothie_css_path__()},
+        {"SMOOTHIE_HTML_ONLY", html_only}
       ]
       System.cmd(path, [], env: env, into: IO.stream(:stdio, :line))
     end
     # force recompilation to ensure changes are realized for the smoothie modules
     Mix.Tasks.Compile.run(["--force"])
+  end
+
+  defp html_only?(argv) do
+    case OptionParser.parse(argv, switches: ["html-only": :boolean]) do
+      {[html_only: html_only], [], []} ->
+        html_only
+      _ ->
+        Application.get_env(:smoothie, :html_only, false)
+    end
   end
 end


### PR DESCRIPTION
To skip generating text templates automatically, either run
```
$ mix smoothie.compile --html-only
```
or set your config with,
```
config :smoothie, html_only: true
```